### PR TITLE
Correct measurement height self.zu and self.zt

### DIFF
--- a/src/pyTSEB.py
+++ b/src/pyTSEB.py
@@ -638,7 +638,7 @@ class PyTSEB():
     def GetDataTSEBWidgets(self,isImage):
         '''Parses the parameters in the GUI to TSEB variables for running TSEB'''
         self.TSEB_MODEL=self.w_model.value
-        self.lat,self.lon,self.alt,self.stdlon,self.z_u,self.z_t=(self.w_lat.value,
+        self.lat,self.lon,self.alt,self.stdlon,self.zu,self.zt=(self.w_lat.value,
                 self.w_lon.value,self.w_alt.value,float(self.w_stdlon.value)*15,
                 self.w_zu.value,self.w_zt.value)
         
@@ -678,7 +678,7 @@ class PyTSEB():
     def GetDataTSEB(self,configdata,isImage):
         '''Parses the parameters in a configuration file directly to TSEB variables for running TSEB'''
         self.TSEB_MODEL=configdata['TSEB_MODEL']
-        self.lat,self.lon,self.alt,self.stdlon,self.z_u,self.z_t=(float(configdata['lat']),
+        self.lat,self.lon,self.alt,self.stdlon,self.zu,self.zt=(float(configdata['lat']),
                 float(configdata['lon']),float(configdata['altitude']),float(configdata['stdlon']),
                 float(configdata['z_u']),float(configdata['z_t']))
       


### PR DESCRIPTION
In the initialization of the PyTSEB class the measurement heights are initialized as self.zu and self.zt. These parameters are also used as inputs for TSEB.py. But while reading the inputs from the configuration file in GetDataTSEB the configuration data is allocated to self.z_t and self.z_u. Thus the initialized values (self.zt and self.zu) are used in the computation of the fluxes.