### PR TITLE
Save as COG instead of GeoTIFF 

### DIFF
--- a/pyTSEB/PyTSEB.py
+++ b/pyTSEB/PyTSEB.py
@@ -909,7 +909,7 @@ class PyTSEB(object):
             rows, cols = np.shape(output['H1'])
             for i, field in enumerate(fields):
                 driver = gdal.GetDriverByName("MEM")
-                out_path = join(out_dir, field + ".tif")
+                out_path = join(out_dir, splitext(basename(outfile))[0] + "_" + field + ".tif")
                 ds = driver.Create("MEM", cols, rows, 1, gdal.GDT_Float32)
                 ds.SetGeoTransform(self.geo)
                 ds.SetProjection(self.prj)


### PR DESCRIPTION
Whenever data is supposed to be saved as GeoTIFF it is saved as COG instead. This does not change anything when displaying the outputs locally but makes it more efficient for displaying online.