### PR TITLE
Use 32 bit floats for most calculations

### DIFF
--- a/pyTSEB/TSEB.py
+++ b/pyTSEB/TSEB.py
@@ -318,7 +318,7 @@ def TSEB_2T(T_C,
     # calcG_params[1] = None
     # Create the output variables
     [flag, Ln_S, Ln_C, LE_C, H_C, LE_S, H_S, G, R_S, R_x,
-        R_A, iterations] = [np.zeros(T_S.shape)+np.NaN for i in range(12)]
+        R_A, iterations] = [np.zeros(T_S.shape, np.float32)+np.NaN for i in range(12)]
     T_AC = T_A_K.copy()
 
     # iteration of the Monin-Obukhov length
@@ -675,10 +675,10 @@ def TSEB_PT(Tr_K,
     # iteration of the Monin-Obukhov length
     if const_L is None:
         # Initially assume stable atmospheric conditions and set variables for
-        L = np.asarray(np.zeros(Tr_K.shape, np.float32) + np.inf, dtype=np.float32)
+        L = np.zeros(Tr_K.shape) + np.inf
         max_iterations = ITERATIONS
     else:  # We force Monin-Obukhov lenght to the provided array/value
-        L = np.asarray(np.ones(Tr_K.shape, np.float32) * const_L, dtype=np.float32)
+        L = np.ones(Tr_K.shape) * const_L
         max_iterations = 1  # No iteration
     # Calculate the general parameters
     rho = met.calc_rho(p, ea, T_A_K)  # Air density
@@ -696,7 +696,7 @@ def TSEB_PT(Tr_K,
     u_friction = MO.calc_u_star(u, z_u, L, d_0, z_0M)
     u_friction = np.asarray(np.maximum(U_FRICTION_MIN, u_friction), dtype=np.float32)
     L_queue = deque([np.array(L, np.float32)], 6)
-    L_converged = np.asarray(np.zeros(Tr_K.shape), dtype=bool)
+    L_converged = np.zeros(Tr_K.shape, bool)
     L_diff_max = np.inf
 
     # First assume that canopy temperature equals the minumum of Air or
@@ -1133,7 +1133,7 @@ def DTD(Tr_K_0,
     resistance_form = resistance_form[0]
     # Create the output variables
     [flag, T_S, T_C, T_AC, Ln_S, Ln_C, LE_C, H_C, LE_S, H_S, G, R_S, R_x,
-        R_A, H, iterations] = [np.zeros(Tr_K_1.shape) + np.NaN for i in range(16)]
+        R_A, H, iterations] = [np.zeros(Tr_K_1.shape, np.float32) + np.NaN for i in range(16)]
 
     # Calculate the general parameters
     rho = met.calc_rho(p, ea, T_A_K_1)  # Air density
@@ -1480,7 +1480,7 @@ def OSEB(Tr_K,
                          calcG_params[1]],
                         [Tr_K] * 12)
     # Create the output variables
-    [flag, Ln, LE, H, G, R_A] = [np.zeros(Tr_K.shape) + np.NaN for i in range(6)]
+    [flag, Ln, LE, H, G, R_A] = [np.zeros(Tr_K.shape, np.float32) + np.NaN for i in range(6)]
 
     # iteration of the Monin-Obukhov length
     if const_L is None:

--- a/pyTSEB/energy_combination_ET.py
+++ b/pyTSEB/energy_combination_ET.py
@@ -154,7 +154,7 @@ def penman_monteith(T_A_K,
                       [T_A_K] * 14)
 
     # Create the output variables
-    [flag, Ln, LE, H, G, R_A, iterations] = [np.zeros(T_A_K.shape) + np.NaN for i in
+    [flag, Ln, LE, H, G, R_A, iterations] = [np.zeros(T_A_K.shape, np.float32) + np.NaN for i in
                                              range(7)]
 
     # Calculate the general parameters
@@ -175,10 +175,10 @@ def penman_monteith(T_A_K,
     # iteration of the Monin-Obukhov length
     if const_L is None:
         # Initially assume stable atmospheric conditions and set variables for
-        L = np.asarray(np.zeros(T_A_K.shape) + np.inf)
+        L = np.zeros(T_A_K.shape) + np.inf
         max_iterations = ITERATIONS
     else:  # We force Monin-Obukhov lenght to the provided array/value
-        L = np.asarray(np.ones(T_A_K.shape) * const_L)
+        L = np.ones(T_A_K.shape) * const_L
         max_iterations = 1  # No iteration
     u_friction = TSEB.MO.calc_u_star(u, z_u, L, d_0, z_0M)
     u_friction = np.asarray(np.maximum(TSEB.U_FRICTION_MIN, u_friction))
@@ -484,8 +484,7 @@ def shuttleworth_wallace(T_A_K,
 
     # Create the output variables
     [flag, vpd_0, LE, H, LE_C, H_C, LE_S, H_S, G, R_S, R_x, R_A,
-     Rn, Rn_C, Rn_S, C_s, C_c, PM_C, PM_S, iterations] = [np.full(T_A_K.shape,
-                                                                  np.NaN)
+     Rn, Rn_C, Rn_S, C_s, C_c, PM_C, PM_S, iterations] = [np.full(T_A_K.shape, np.NaN, np.float32)
                                                           for i in range(20)]
 
     # Calculate the general parameters
@@ -511,10 +510,10 @@ def shuttleworth_wallace(T_A_K,
     # iteration of the Monin-Obukhov length
     if const_L is None:
         # Initially assume stable atmospheric conditions and set variables for
-        L = np.asarray(np.zeros(T_A_K.shape) + np.inf)
+        L = np.zeros(T_A_K.shape) + np.inf
         max_iterations = ITERATIONS
     else:  # We force Monin-Obukhov lenght to the provided array/value
-        L = np.asarray(np.ones(T_A_K.shape) * const_L)
+        L = np.ones(T_A_K.shape) * const_L
         max_iterations = 1  # No iteration
     u_friction = TSEB.MO.calc_u_star(u, z_u, L, d_0, z_0M)
     u_friction = np.asarray(np.maximum(TSEB.U_FRICTION_MIN, u_friction))
@@ -871,7 +870,7 @@ def penman(T_A_K,
                       [T_A_K] * 11)
 
     # Create the output variables
-    [flag, Ln, LE, H, G, R_A, iterations] = [np.zeros(T_A_K.shape) + np.NaN for i in
+    [flag, Ln, LE, H, G, R_A, iterations] = [np.zeros(T_A_K.shape, np.float32) + np.NaN for i in
                                              range(7)]
 
     # Calculate the general parameters
@@ -889,10 +888,10 @@ def penman(T_A_K,
     # iteration of the Monin-Obukhov length
     if const_L is None:
         # Initially assume stable atmospheric conditions and set variables for
-        L = np.asarray(np.zeros(T_A_K.shape) + np.inf)
+        L = np.zeros(T_A_K.shape) + np.inf
         max_iterations = ITERATIONS
     else:  # We force Monin-Obukhov lenght to the provided array/value
-        L = np.asarray(np.ones(T_A_K.shape) * const_L)
+        L = np.ones(T_A_K.shape) * const_L
         max_iterations = 1  # No iteration
     u_friction = TSEB.MO.calc_u_star(u, z_u, L, d_0, z_0M)
     u_friction = np.asarray(np.maximum(TSEB.U_FRICTION_MIN, u_friction))


### PR DESCRIPTION
This reduces memory use by about a third and speeds up computation by a similar factor while leaving the output values virtually unchanged.