### PR TITLE
Add Py6S to the environment.yml file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
     - notebook
     - bokeh
     - netCDF4
+    - Py6S
     - pip
     - pip:
         - git+https://github.com/hectornieto/pypro4sail


### PR DESCRIPTION
To fix an installation error, Py6S library needs to be installed or added to the environment.yml file